### PR TITLE
Fix D-Bus service exec path

### DIFF
--- a/Scripts/org.clightd.clightd.service
+++ b/Scripts/org.clightd.clightd.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.clightd.clightd
-Exec=@DAEMON_DIR@/clightd
+Exec=@CMAKE_INSTALL_FULL_LIBEXECDIR@/clightd
 User=root
 SystemdService=clightd.service


### PR DESCRIPTION
As a follow-up for 2a32d012e30772d1b5108be381e7884f01fb05d0, and an attempt to fix #55, this PR cleans up a remaining instance of the previously used `DAEMON_DIR` variable.