### PR TITLE
Raise minimum cmake version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 project(clightd VERSION 5.2 LANGUAGES C)
 


### PR DESCRIPTION
NAME_WLE was added to get_filename_component() only in that version.
