### PR TITLE
Logarithmic ALS Scaling

### DIFF
--- a/src/modules/sensors/als.c
+++ b/src/modules/sensors/als.c
@@ -2,8 +2,8 @@
 #include <udev.h>
 
 #define ALS_NAME            "Als"
-#define ALS_ILL_MAX         500
-#define ALS_ILL_MIN         22
+#define ALS_ILL_MAX         100000 // Direct Sunlight
+#define ALS_ILL_MIN         20 // Dark Room
 #define ALS_INTERVAL        20 // ms
 #define ALS_SUBSYSTEM       "iio"
 
@@ -101,11 +101,11 @@ static void parse_settings(char *settings, int *min, int *max, int *interval) {
         fprintf(stderr, "Wrong interval value. Resetting default.\n");
         *interval = ALS_INTERVAL;
     }
-    if (*min < 0) {
+    if (*min < 1) {
         fprintf(stderr, "Wrong min value. Resetting default.\n");
         *min = ALS_ILL_MIN;
     }
-    if (*max < 0) {
+    if (*max < 1) {
         fprintf(stderr, "Wrong max value. Resetting default.\n");
         *max = ALS_ILL_MAX;
     }
@@ -146,8 +146,12 @@ static int capture(void *dev, double *pct, const int num_captures, char *setting
             }
         }
 
-        if (illuminance >= 0) {
-            pct[ctr++] = illuminance / max;
+        if (illuminance >= 1) {
+            if (illuminance != min) {
+                pct[ctr++] = (log10(illuminance) - log10(min)) / log10(max);
+            } else if (illuminance == min) {
+                pct[ctr++] = 0.01;
+            }
         }
 
         usleep(interval * 1000);

--- a/src/modules/sensors/als.c
+++ b/src/modules/sensors/als.c
@@ -148,7 +148,7 @@ static int capture(void *dev, double *pct, const int num_captures, char *setting
 
         if (illuminance >= 1) {
             if (illuminance != min) {
-                pct[ctr++] = (log10(illuminance) - log10(min)) / log10(max);
+                pct[ctr++] = log10(illuminance) / log10(max);
             } else if (illuminance == min) {
                 pct[ctr++] = 0.01;
             }

--- a/src/modules/sensors/als.c
+++ b/src/modules/sensors/als.c
@@ -2,6 +2,7 @@
 #include <udev.h>
 
 #define ALS_NAME            "Als"
+/* For more on interpreting lux values: https://docs.microsoft.com/en-us/windows/win32/sensorsapi/understanding-and-interpreting-lux-values */
 #define ALS_ILL_MAX         100000 // Direct Sunlight
 #define ALS_ILL_MIN         20 // Dark Room
 #define ALS_INTERVAL        20 // ms

--- a/src/modules/sensors/als.c
+++ b/src/modules/sensors/als.c
@@ -3,14 +3,14 @@
 
 #define ALS_NAME            "Als"
 /* For more on interpreting lux values: https://docs.microsoft.com/en-us/windows/win32/sensorsapi/understanding-and-interpreting-lux-values */
-#define ALS_ILL_MAX         100000 // Direct Sunlight
-#define ALS_ILL_MIN         20 // Dark Room
+#define ALS_ILL_MAX         100000 // Direct sunlight
+#define ALS_ILL_MIN         1 // Pitch black
 #define ALS_INTERVAL        20 // ms
 #define ALS_SUBSYSTEM       "iio"
 
 SENSOR(ALS_NAME);
 
-static void parse_settings(char *settings, int *min, int *max, int *interval);
+static void parse_settings(char *settings, int *interval);
 
 /* properties names to be checked. "in_illuminance_input" has higher priority. */
 static const char *ill_names[] = { "in_illuminance_input", "in_illuminance_raw", "in_intensity_clear_raw" };
@@ -62,13 +62,11 @@ static void destroy_monitor(void) {
     udev_monitor_unref(mon);
 }
 
-static void parse_settings(char *settings, int *min, int *max, int *interval) {
-    const char opts[] = { 'i', 'm', 'M' };
-    int *vals[] = { interval, min, max };
+static void parse_settings(char *settings, int *interval) {
+    const char opts[] = { 'i' };
+    int *vals[] = { interval };
 
     /* Default values */
-    *min = ALS_ILL_MIN;
-    *max = ALS_ILL_MAX;
     *interval = ALS_INTERVAL;
 
     if (settings && strlen(settings)) {
@@ -102,24 +100,14 @@ static void parse_settings(char *settings, int *min, int *max, int *interval) {
         fprintf(stderr, "Wrong interval value. Resetting default.\n");
         *interval = ALS_INTERVAL;
     }
-    if (*min < 1) {
-        fprintf(stderr, "Wrong min value. Resetting default.\n");
-        *min = ALS_ILL_MIN;
-    }
-    if (*max < 1) {
-        fprintf(stderr, "Wrong max value. Resetting default.\n");
-        *max = ALS_ILL_MAX;
-    }
-    if (*min > *max) {
-        fprintf(stderr, "Wrong min/max values. Resetting defaults.\n");
-        *min = ALS_ILL_MIN;
-        *max = ALS_ILL_MAX;
-    }
 }
 
 static int capture(void *dev, double *pct, const int num_captures, char *settings) {
-    int min, max, interval;
-    parse_settings(settings, &min, &max, &interval);
+    int interval;
+    parse_settings(settings, &interval);
+
+    int min = ALS_ILL_MIN;
+    int max = ALS_ILL_MAX;
 
     int ctr = 0;
     const char *val = NULL;
@@ -148,11 +136,7 @@ static int capture(void *dev, double *pct, const int num_captures, char *setting
         }
 
         if (illuminance >= 1) {
-            if (illuminance != min) {
-                pct[ctr++] = log10(illuminance) / log10(max);
-            } else if (illuminance == min) {
-                pct[ctr++] = 0.01;
-            }
+            pct[ctr++] = log10(illuminance) / log10(max);
         }
 
         usleep(interval * 1000);


### PR DESCRIPTION
This is what I had in mind for logarithmic scaling; I changed the default MIN and MAX values based on [this general guideline for interpreting lux](https://docs.microsoft.com/en-us/windows/win32/sensorsapi/understanding-and-interpreting-lux-values).

Ensuring min and max >= 1 prevents negative log values.

I am unsure if this breaks any previous compatibilities or expected behaviors, so feel free to change it how you see fit. I also don't code in C so apologies if something is blatantly wrong.