### PR TITLE
pure dmabuf implementation of screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,14 @@ endmacro()
 
 optional_dep(GAMMA "x11;xrandr;libdrm;wayland-client" "Gamma correction" protocol/wlr-gamma-control-unstable-v1.xml src/modules/gamma_plugins)
 optional_dep(DPMS "x11;xext;libdrm;wayland-client" "DPMS" protocol/org_kde_kwin_dpms.xml src/modules/dpms_plugins)
-optional_dep(SCREEN "x11" "screen emitted brightness" protocol/wlr-screencopy-unstable-v1.xml src/modules/screen_plugins)
+# I'm not sure how to include the protocols with the current macros you
+# have. In simpler words, it would be useful to include the
+# wlr-output-management-unstable-v1 protocol for all wayland modules.
+optional_dep(SCREEN "x11;wayland-client" "screen emitted brightness" protocol/wlr-output-management-unstable-v1.xml src/modules/screen_plugins)
+# These protocols are necesary only for the SCREEN module
+optional_dep(SCREEN "x11;wayland-client" "screen emitted brightness" protocol/linux-dmabuf-unstable-v1.xml src/modules/screen_plugins)
+optional_dep(SCREEN "x11;wayland-client" "screen emitted brightness" protocol/wlr-export-dmabuf-unstable-v1.xml src/modules/screen_plugins)
+optional_dep(SCREEN "x11;wayland-client" "screen emitted brightness" protocol/wlr-screencopy-unstable-v1.xml src/modules/screen_plugins)
 optional_dep(DDC "ddcutil>=0.9.5" "external monitor backlight")
 optional_dep(YOCTOLIGHT "libusb-1.0" "Yoctolight usb als devices support")
 optional_dep(PIPEWIRE "libpipewire-0.3" "Enable pipewire camera sensor support")

--- a/protocol/linux-dmabuf-unstable-v1.xml
+++ b/protocol/linux-dmabuf-unstable-v1.xml
@@ -1,0 +1,586 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="linux_dmabuf_unstable_v1">
+
+  <copyright>
+    Copyright © 2014, 2015 Collabora, Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_linux_dmabuf_v1" version="4">
+    <description summary="factory for creating dmabuf-based wl_buffers">
+      Following the interfaces from:
+      https://www.khronos.org/registry/egl/extensions/EXT/EGL_EXT_image_dma_buf_import.txt
+      https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt
+      and the Linux DRM sub-system's AddFb2 ioctl.
+
+      This interface offers ways to create generic dmabuf-based wl_buffers.
+
+      Clients can use the get_surface_feedback request to get dmabuf feedback
+      for a particular surface. If the client wants to retrieve feedback not
+      tied to a surface, they can use the get_default_feedback request.
+
+      The following are required from clients:
+
+      - Clients must ensure that either all data in the dma-buf is
+        coherent for all subsequent read access or that coherency is
+        correctly handled by the underlying kernel-side dma-buf
+        implementation.
+
+      - Don't make any more attachments after sending the buffer to the
+        compositor. Making more attachments later increases the risk of
+        the compositor not being able to use (re-import) an existing
+        dmabuf-based wl_buffer.
+
+      The underlying graphics stack must ensure the following:
+
+      - The dmabuf file descriptors relayed to the server will stay valid
+        for the whole lifetime of the wl_buffer. This means the server may
+        at any time use those fds to import the dmabuf into any kernel
+        sub-system that might accept it.
+
+      However, when the underlying graphics stack fails to deliver the
+      promise, because of e.g. a device hot-unplug which raises internal
+      errors, after the wl_buffer has been successfully created the
+      compositor must not raise protocol errors to the client when dmabuf
+      import later fails.
+
+      To create a wl_buffer from one or more dmabufs, a client creates a
+      zwp_linux_dmabuf_params_v1 object with a zwp_linux_dmabuf_v1.create_params
+      request. All planes required by the intended format are added with
+      the 'add' request. Finally, a 'create' or 'create_immed' request is
+      issued, which has the following outcome depending on the import success.
+
+      The 'create' request,
+      - on success, triggers a 'created' event which provides the final
+        wl_buffer to the client.
+      - on failure, triggers a 'failed' event to convey that the server
+        cannot use the dmabufs received from the client.
+
+      For the 'create_immed' request,
+      - on success, the server immediately imports the added dmabufs to
+        create a wl_buffer. No event is sent from the server in this case.
+      - on failure, the server can choose to either:
+        - terminate the client by raising a fatal error.
+        - mark the wl_buffer as failed, and send a 'failed' event to the
+          client. If the client uses a failed wl_buffer as an argument to any
+          request, the behaviour is compositor implementation-defined.
+
+      For all DRM formats and unless specified in another protocol extension,
+      pre-multiplied alpha is used for pixel values.
+
+      Warning! The protocol described in this file is experimental and
+      backward incompatible changes may be made. Backward compatible changes
+      may be added together with the corresponding interface version bump.
+      Backward incompatible changes are done by bumping the version number in
+      the protocol and interface names and resetting the interface version.
+      Once the protocol is to be declared stable, the 'z' prefix and the
+      version number in the protocol and interface names are removed and the
+      interface version number is reset.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind the factory">
+        Objects created through this interface, especially wl_buffers, will
+        remain valid.
+      </description>
+    </request>
+
+    <request name="create_params">
+      <description summary="create a temporary object for buffer parameters">
+        This temporary object is used to collect multiple dmabuf handles into
+        a single batch to create a wl_buffer. It can only be used once and
+        should be destroyed after a 'created' or 'failed' event has been
+        received.
+      </description>
+      <arg name="params_id" type="new_id" interface="zwp_linux_buffer_params_v1"
+           summary="the new temporary"/>
+    </request>
+
+    <event name="format">
+      <description summary="supported buffer format">
+        This event advertises one buffer format that the server supports.
+        All the supported formats are advertised once when the client
+        binds to this interface. A roundtrip after binding guarantees
+        that the client has received all supported formats.
+
+        For the definition of the format codes, see the
+        zwp_linux_buffer_params_v1::create request.
+
+        Starting version 4, the format event is deprecated and must not be
+        sent by compositors. Instead, use get_default_feedback or
+        get_surface_feedback.
+      </description>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+    </event>
+
+    <event name="modifier" since="3">
+      <description summary="supported buffer format modifier">
+        This event advertises the formats that the server supports, along with
+        the modifiers supported for each format. All the supported modifiers
+        for all the supported formats are advertised once when the client
+        binds to this interface. A roundtrip after binding guarantees that
+        the client has received all supported format-modifier pairs.
+
+        For legacy support, DRM_FORMAT_MOD_INVALID (that is, modifier_hi ==
+        0x00ffffff and modifier_lo == 0xffffffff) is allowed in this event.
+        It indicates that the server can support the format with an implicit
+        modifier. When a plane has DRM_FORMAT_MOD_INVALID as its modifier, it
+        is as if no explicit modifier is specified. The effective modifier
+        will be derived from the dmabuf.
+
+        A compositor that sends valid modifiers and DRM_FORMAT_MOD_INVALID for
+        a given format supports both explicit modifiers and implicit modifiers.
+
+        For the definition of the format and modifier codes, see the
+        zwp_linux_buffer_params_v1::create and zwp_linux_buffer_params_v1::add
+        requests.
+
+        Starting version 4, the modifier event is deprecated and must not be
+        sent by compositors. Instead, use get_default_feedback or
+        get_surface_feedback.
+      </description>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+      <arg name="modifier_hi" type="uint"
+           summary="high 32 bits of layout modifier"/>
+      <arg name="modifier_lo" type="uint"
+           summary="low 32 bits of layout modifier"/>
+    </event>
+
+    <!-- Version 4 additions -->
+
+    <request name="get_default_feedback" since="4">
+      <description summary="get default feedback">
+        This request creates a new wp_linux_dmabuf_feedback object not bound
+        to a particular surface. This object will deliver feedback about dmabuf
+        parameters to use if the client doesn't support per-surface feedback
+        (see get_surface_feedback).
+      </description>
+      <arg name="id" type="new_id" interface="zwp_linux_dmabuf_feedback_v1"/>
+    </request>
+
+    <request name="get_surface_feedback" since="4">
+      <description summary="get feedback for a surface">
+        This request creates a new wp_linux_dmabuf_feedback object for the
+        specified wl_surface. This object will deliver feedback about dmabuf
+        parameters to use for buffers attached to this surface.
+
+        If the surface is destroyed before the wp_linux_dmabuf_feedback object,
+        the feedback object becomes inert.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_linux_dmabuf_feedback_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_linux_buffer_params_v1" version="4">
+    <description summary="parameters for creating a dmabuf-based wl_buffer">
+      This temporary object is a collection of dmabufs and other
+      parameters that together form a single logical buffer. The temporary
+      object may eventually create one wl_buffer unless cancelled by
+      destroying it before requesting 'create'.
+
+      Single-planar formats only require one dmabuf, however
+      multi-planar formats may require more than one dmabuf. For all
+      formats, an 'add' request must be called once per plane (even if the
+      underlying dmabuf fd is identical).
+
+      You must use consecutive plane indices ('plane_idx' argument for 'add')
+      from zero to the number of planes used by the drm_fourcc format code.
+      All planes required by the format must be given exactly once, but can
+      be given in any order. Each plane index can be set only once.
+    </description>
+
+    <enum name="error">
+      <entry name="already_used" value="0"
+             summary="the dmabuf_batch object has already been used to create a wl_buffer"/>
+      <entry name="plane_idx" value="1"
+             summary="plane index out of bounds"/>
+      <entry name="plane_set" value="2"
+             summary="the plane index was already set"/>
+      <entry name="incomplete" value="3"
+             summary="missing or too many planes to create a buffer"/>
+      <entry name="invalid_format" value="4"
+             summary="format not supported"/>
+      <entry name="invalid_dimensions" value="5"
+             summary="invalid width or height"/>
+      <entry name="out_of_bounds" value="6"
+             summary="offset + stride * height goes out of dmabuf bounds"/>
+      <entry name="invalid_wl_buffer" value="7"
+             summary="invalid wl_buffer resulted from importing dmabufs via
+               the create_immed request on given buffer_params"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Cleans up the temporary data sent to the server for dmabuf-based
+        wl_buffer creation.
+      </description>
+    </request>
+
+    <request name="add">
+      <description summary="add a dmabuf to the temporary set">
+        This request adds one dmabuf to the set in this
+        zwp_linux_buffer_params_v1.
+
+        The 64-bit unsigned value combined from modifier_hi and modifier_lo
+        is the dmabuf layout modifier. DRM AddFB2 ioctl calls this the
+        fb modifier, which is defined in drm_mode.h of Linux UAPI.
+        This is an opaque token. Drivers use this token to express tiling,
+        compression, etc. driver-specific modifications to the base format
+        defined by the DRM fourcc code.
+
+        Starting from version 4, the invalid_format protocol error is sent if
+        the format + modifier pair was not advertised as supported.
+
+        This request raises the PLANE_IDX error if plane_idx is too large.
+        The error PLANE_SET is raised if attempting to set a plane that
+        was already set.
+      </description>
+      <arg name="fd" type="fd" summary="dmabuf fd"/>
+      <arg name="plane_idx" type="uint" summary="plane index"/>
+      <arg name="offset" type="uint" summary="offset in bytes"/>
+      <arg name="stride" type="uint" summary="stride in bytes"/>
+      <arg name="modifier_hi" type="uint"
+           summary="high 32 bits of layout modifier"/>
+      <arg name="modifier_lo" type="uint"
+           summary="low 32 bits of layout modifier"/>
+    </request>
+
+    <enum name="flags" bitfield="true">
+      <entry name="y_invert" value="1" summary="contents are y-inverted"/>
+      <entry name="interlaced" value="2" summary="content is interlaced"/>
+      <entry name="bottom_first" value="4" summary="bottom field first"/>
+    </enum>
+
+    <request name="create">
+      <description summary="create a wl_buffer from the given dmabufs">
+        This asks for creation of a wl_buffer from the added dmabuf
+        buffers. The wl_buffer is not created immediately but returned via
+        the 'created' event if the dmabuf sharing succeeds. The sharing
+        may fail at runtime for reasons a client cannot predict, in
+        which case the 'failed' event is triggered.
+
+        The 'format' argument is a DRM_FORMAT code, as defined by the
+        libdrm's drm_fourcc.h. The Linux kernel's DRM sub-system is the
+        authoritative source on how the format codes should work.
+
+        The 'flags' is a bitfield of the flags defined in enum "flags".
+        'y_invert' means the that the image needs to be y-flipped.
+
+        Flag 'interlaced' means that the frame in the buffer is not
+        progressive as usual, but interlaced. An interlaced buffer as
+        supported here must always contain both top and bottom fields.
+        The top field always begins on the first pixel row. The temporal
+        ordering between the two fields is top field first, unless
+        'bottom_first' is specified. It is undefined whether 'bottom_first'
+        is ignored if 'interlaced' is not set.
+
+        This protocol does not convey any information about field rate,
+        duration, or timing, other than the relative ordering between the
+        two fields in one buffer. A compositor may have to estimate the
+        intended field rate from the incoming buffer rate. It is undefined
+        whether the time of receiving wl_surface.commit with a new buffer
+        attached, applying the wl_surface state, wl_surface.frame callback
+        trigger, presentation, or any other point in the compositor cycle
+        is used to measure the frame or field times. There is no support
+        for detecting missed or late frames/fields/buffers either, and
+        there is no support whatsoever for cooperating with interlaced
+        compositor output.
+
+        The composited image quality resulting from the use of interlaced
+        buffers is explicitly undefined. A compositor may use elaborate
+        hardware features or software to deinterlace and create progressive
+        output frames from a sequence of interlaced input buffers, or it
+        may produce substandard image quality. However, compositors that
+        cannot guarantee reasonable image quality in all cases are recommended
+        to just reject all interlaced buffers.
+
+        Any argument errors, including non-positive width or height,
+        mismatch between the number of planes and the format, bad
+        format, bad offset or stride, may be indicated by fatal protocol
+        errors: INCOMPLETE, INVALID_FORMAT, INVALID_DIMENSIONS,
+        OUT_OF_BOUNDS.
+
+        Dmabuf import errors in the server that are not obvious client
+        bugs are returned via the 'failed' event as non-fatal. This
+        allows attempting dmabuf sharing and falling back in the client
+        if it fails.
+
+        This request can be sent only once in the object's lifetime, after
+        which the only legal request is destroy. This object should be
+        destroyed after issuing a 'create' request. Attempting to use this
+        object after issuing 'create' raises ALREADY_USED protocol error.
+
+        It is not mandatory to issue 'create'. If a client wants to
+        cancel the buffer creation, it can just destroy this object.
+      </description>
+      <arg name="width" type="int" summary="base plane width in pixels"/>
+      <arg name="height" type="int" summary="base plane height in pixels"/>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+      <arg name="flags" type="uint" enum="flags" summary="see enum flags"/>
+    </request>
+
+    <event name="created">
+      <description summary="buffer creation succeeded">
+        This event indicates that the attempted buffer creation was
+        successful. It provides the new wl_buffer referencing the dmabuf(s).
+
+        Upon receiving this event, the client should destroy the
+        zlinux_dmabuf_params object.
+      </description>
+      <arg name="buffer" type="new_id" interface="wl_buffer"
+           summary="the newly created wl_buffer"/>
+    </event>
+
+    <event name="failed">
+      <description summary="buffer creation failed">
+        This event indicates that the attempted buffer creation has
+        failed. It usually means that one of the dmabuf constraints
+        has not been fulfilled.
+
+        Upon receiving this event, the client should destroy the
+        zlinux_buffer_params object.
+      </description>
+    </event>
+
+    <request name="create_immed" since="2">
+      <description summary="immediately create a wl_buffer from the given
+                     dmabufs">
+        This asks for immediate creation of a wl_buffer by importing the
+        added dmabufs.
+
+        In case of import success, no event is sent from the server, and the
+        wl_buffer is ready to be used by the client.
+
+        Upon import failure, either of the following may happen, as seen fit
+        by the implementation:
+        - the client is terminated with one of the following fatal protocol
+          errors:
+          - INCOMPLETE, INVALID_FORMAT, INVALID_DIMENSIONS, OUT_OF_BOUNDS,
+            in case of argument errors such as mismatch between the number
+            of planes and the format, bad format, non-positive width or
+            height, or bad offset or stride.
+          - INVALID_WL_BUFFER, in case the cause for failure is unknown or
+            plaform specific.
+        - the server creates an invalid wl_buffer, marks it as failed and
+          sends a 'failed' event to the client. The result of using this
+          invalid wl_buffer as an argument in any request by the client is
+          defined by the compositor implementation.
+
+        This takes the same arguments as a 'create' request, and obeys the
+        same restrictions.
+      </description>
+      <arg name="buffer_id" type="new_id" interface="wl_buffer"
+           summary="id for the newly created wl_buffer"/>
+      <arg name="width" type="int" summary="base plane width in pixels"/>
+      <arg name="height" type="int" summary="base plane height in pixels"/>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+      <arg name="flags" type="uint" enum="flags" summary="see enum flags"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_linux_dmabuf_feedback_v1" version="4">
+    <description summary="dmabuf feedback">
+      This object advertises dmabuf parameters feedback. This includes the
+      preferred devices and the supported formats/modifiers.
+
+      The parameters are sent once when this object is created and whenever they
+      change. The done event is always sent once after all parameters have been
+      sent. When a single parameter changes, all parameters are re-sent by the
+      compositor.
+
+      Compositors can re-send the parameters when the current client buffer
+      allocations are sub-optimal. Compositors should not re-send the
+      parameters if re-allocating the buffers would not result in a more optimal
+      configuration. In particular, compositors should avoid sending the exact
+      same parameters multiple times in a row.
+
+      The tranche_target_device and tranche_formats events are grouped by
+      tranches of preference. For each tranche, a tranche_target_device, one
+      tranche_flags and one or more tranche_formats events are sent, followed
+      by a tranche_done event finishing the list. The tranches are sent in
+      descending order of preference. All formats and modifiers in the same
+      tranche have the same preference.
+
+      To send parameters, the compositor sends one main_device event, tranches
+      (each consisting of one tranche_target_device event, one tranche_flags
+      event, tranche_formats events and then a tranche_done event), then one
+      done event.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the feedback object">
+        Using this request a client can tell the server that it is not going to
+        use the wp_linux_dmabuf_feedback object anymore.
+      </description>
+    </request>
+
+    <event name="done">
+      <description summary="all feedback has been sent">
+        This event is sent after all parameters of a wp_linux_dmabuf_feedback
+        object have been sent.
+
+        This allows changes to the wp_linux_dmabuf_feedback parameters to be
+        seen as atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <event name="format_table">
+      <description summary="format and modifier table">
+        This event provides a file descriptor which can be memory-mapped to
+        access the format and modifier table.
+
+        The table contains a tightly packed array of consecutive format +
+        modifier pairs. Each pair is 16 bytes wide. It contains a format as a
+        32-bit unsigned integer, followed by 4 bytes of unused padding, and a
+        modifier as a 64-bit unsigned integer. The native endianness is used.
+
+        The client must map the file descriptor in read-only private mode.
+
+        Compositors are not allowed to mutate the table file contents once this
+        event has been sent. Instead, compositors must create a new, separate
+        table file and re-send feedback parameters. Compositors are allowed to
+        store duplicate format + modifier pairs in the table.
+      </description>
+      <arg name="fd" type="fd" summary="table file descriptor"/>
+      <arg name="size" type="uint" summary="table size, in bytes"/>
+    </event>
+
+    <event name="main_device">
+      <description summary="preferred main device">
+        This event advertises the main device that the server prefers to use
+        when direct scan-out to the target device isn't possible. The
+        advertised main device may be different for each
+        wp_linux_dmabuf_feedback object, and may change over time.
+
+        There is exactly one main device. The compositor must send at least
+        one preference tranche with tranche_target_device equal to main_device.
+
+        Clients need to create buffers that the main device can import and
+        read from, otherwise creating the dmabuf wl_buffer will fail (see the
+        wp_linux_buffer_params.create and create_immed requests for details).
+        The main device will also likely be kept active by the compositor,
+        so clients can use it instead of waking up another device for power
+        savings.
+
+        In general the device is a DRM node. The DRM node type (primary vs.
+        render) is unspecified. Clients must not rely on the compositor sending
+        a particular node type. Clients cannot check two devices for equality
+        by comparing the dev_t value.
+
+        If explicit modifiers are not supported and the client performs buffer
+        allocations on a different device than the main device, then the client
+        must force the buffer to have a linear layout.
+      </description>
+      <arg name="device" type="array" summary="device dev_t value"/>
+    </event>
+
+    <event name="tranche_done">
+      <description summary="a preference tranche has been sent">
+        This event splits tranche_target_device and tranche_formats events in
+        preference tranches. It is sent after a set of tranche_target_device
+        and tranche_formats events; it represents the end of a tranche. The
+        next tranche will have a lower preference.
+      </description>
+    </event>
+
+    <event name="tranche_target_device">
+      <description summary="target device">
+        This event advertises the target device that the server prefers to use
+        for a buffer created given this tranche. The advertised target device
+        may be different for each preference tranche, and may change over time.
+
+        There is exactly one target device per tranche.
+
+        The target device may be a scan-out device, for example if the
+        compositor prefers to directly scan-out a buffer created given this
+        tranche. The target device may be a rendering device, for example if
+        the compositor prefers to texture from said buffer.
+
+        The client can use this hint to allocate the buffer in a way that makes
+        it accessible from the target device, ideally directly. The buffer must
+        still be accessible from the main device, either through direct import
+        or through a potentially more expensive fallback path. If the buffer
+        can't be directly imported from the main device then clients must be
+        prepared for the compositor changing the tranche priority or making
+        wl_buffer creation fail (see the wp_linux_buffer_params.create and
+        create_immed requests for details).
+
+        If the device is a DRM node, the DRM node type (primary vs. render) is
+        unspecified. Clients must not rely on the compositor sending a
+        particular node type. Clients cannot check two devices for equality by
+        comparing the dev_t value.
+
+        This event is tied to a preference tranche, see the tranche_done event.
+      </description>
+      <arg name="device" type="array" summary="device dev_t value"/>
+    </event>
+
+    <event name="tranche_formats">
+      <description summary="supported buffer format modifier">
+        This event advertises the format + modifier combinations that the
+        compositor supports.
+
+        It carries an array of indices, each referring to a format + modifier
+        pair in the last received format table (see the format_table event).
+        Each index is a 16-bit unsigned integer in native endianness.
+
+        For legacy support, DRM_FORMAT_MOD_INVALID is an allowed modifier.
+        It indicates that the server can support the format with an implicit
+        modifier. When a buffer has DRM_FORMAT_MOD_INVALID as its modifier, it
+        is as if no explicit modifier is specified. The effective modifier
+        will be derived from the dmabuf.
+
+        A compositor that sends valid modifiers and DRM_FORMAT_MOD_INVALID for
+        a given format supports both explicit modifiers and implicit modifiers.
+
+        Compositors must not send duplicate format + modifier pairs within the
+        same tranche or across two different tranches with the same target
+        device and flags.
+
+        This event is tied to a preference tranche, see the tranche_done event.
+
+        For the definition of the format and modifier codes, see the
+        wp_linux_buffer_params.create request.
+      </description>
+      <arg name="indices" type="array" summary="array of 16-bit indexes"/>
+    </event>
+
+    <enum name="tranche_flags" bitfield="true">
+      <entry name="scanout" value="1" summary="direct scan-out tranche"/>
+    </enum>
+
+    <event name="tranche_flags">
+      <description summary="tranche flags">
+        This event sets tranche-specific flags.
+
+        The scanout flag is a hint that direct scan-out may be attempted by the
+        compositor on the target device if the client appropriately allocates a
+        buffer. How to allocate a buffer that can be scanned out on the target
+        device is implementation-defined.
+
+        This event is tied to a preference tranche, see the tranche_done event.
+      </description>
+      <arg name="flags" type="uint" enum="tranche_flags" summary="tranche flags"/>
+    </event>
+  </interface>
+
+</protocol>

--- a/protocol/wlr-export-dmabuf-unstable-v1.xml
+++ b/protocol/wlr-export-dmabuf-unstable-v1.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_export_dmabuf_unstable_v1">
+  <copyright>
+    Copyright © 2018 Rostislav Pehlivanov
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="a protocol for low overhead screen content capturing">
+    An interface to capture surfaces in an efficient way by exporting DMA-BUFs.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_export_dmabuf_manager_v1" version="1">
+    <description summary="manager to inform clients and begin capturing">
+      This object is a manager with which to start capturing from sources.
+    </description>
+
+    <request name="capture_output">
+      <description summary="capture a frame from an output">
+        Capture the next frame of a an entire output.
+      </description>
+      <arg name="frame" type="new_id" interface="zwlr_export_dmabuf_frame_v1"/>
+      <arg name="overlay_cursor" type="int"
+           summary="include custom client hardware cursor on top of the frame"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_export_dmabuf_frame_v1" version="1">
+    <description summary="a DMA-BUF frame">
+      This object represents a single DMA-BUF frame.
+
+      If the capture is successful, the compositor will first send a "frame"
+      event, followed by one or several "object". When the frame is available
+      for readout, the "ready" event is sent.
+
+      If the capture failed, the "cancel" event is sent. This can happen anytime
+      before the "ready" event.
+
+      Once either a "ready" or a "cancel" event is received, the client should
+      destroy the frame. Once an "object" event is received, the client is
+      responsible for closing the associated file descriptor.
+
+      All frames are read-only and may not be written into or altered.
+    </description>
+
+    <enum name="flags">
+      <description summary="frame flags">
+        Special flags that should be respected by the client.
+      </description>
+      <entry name="transient" value="0x1"
+             summary="clients should copy frame before processing"/>
+    </enum>
+
+    <event name="frame">
+      <description summary="a frame description">
+        Main event supplying the client with information about the frame. If the
+        capture didn't fail, this event is always emitted first before any other
+        events.
+
+        This event is followed by a number of "object" as specified by the
+        "num_objects" argument.
+      </description>
+      <arg name="width" type="uint"
+           summary="frame width in pixels"/>
+      <arg name="height" type="uint"
+           summary="frame height in pixels"/>
+      <arg name="offset_x" type="uint"
+           summary="crop offset for the x axis"/>
+      <arg name="offset_y" type="uint"
+           summary="crop offset for the y axis"/>
+      <arg name="buffer_flags" type="uint"
+           summary="flags which indicate properties (invert, interlacing),
+                    has the same values as zwp_linux_buffer_params_v1:flags"/>
+      <arg name="flags" type="uint" enum="flags"
+           summary="indicates special frame features"/>
+      <arg name="format" type="uint"
+           summary="format of the frame (DRM_FORMAT_*)"/>
+      <arg name="mod_high" type="uint"
+           summary="drm format modifier, high"/>
+      <arg name="mod_low" type="uint"
+           summary="drm format modifier, low"/>
+      <arg name="num_objects" type="uint"
+           summary="indicates how many objects (FDs) the frame has (max 4)"/>
+    </event>
+
+    <event name="object">
+      <description summary="an object description">
+        Event which serves to supply the client with the file descriptors
+        containing the data for each object.
+
+        After receiving this event, the client must always close the file
+        descriptor as soon as they're done with it and even if the frame fails.
+      </description>
+      <arg name="index" type="uint"
+           summary="index of the current object"/>
+      <arg name="fd" type="fd"
+           summary="fd of the current object"/>
+      <arg name="size" type="uint"
+           summary="size in bytes for the current object"/>
+      <arg name="offset" type="uint"
+           summary="starting point for the data in the object's fd"/>
+      <arg name="stride" type="uint"
+           summary="line size in bytes"/>
+      <arg name="plane_index" type="uint"
+           summary="index of the the plane the data in the object applies to"/>
+    </event>
+
+    <event name="ready">
+      <description summary="indicates frame is available for reading">
+        This event is sent as soon as the frame is presented, indicating it is
+        available for reading. This event includes the time at which
+        presentation happened at.
+
+        The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
+        each component being an unsigned 32-bit value. Whole seconds are in
+        tv_sec which is a 64-bit value combined from tv_sec_hi and tv_sec_lo,
+        and the additional fractional part in tv_nsec as nanoseconds. Hence,
+        for valid timestamps tv_nsec must be in [0, 999999999]. The seconds part
+        may have an arbitrary offset at start.
+
+        After receiving this event, the client should destroy this object.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <enum name="cancel_reason">
+      <description summary="cancel reason">
+        Indicates reason for cancelling the frame.
+      </description>
+      <entry name="temporary" value="0"
+             summary="temporary error, source will produce more frames"/>
+      <entry name="permanent" value="1"
+             summary="fatal error, source will not produce frames"/>
+      <entry name="resizing" value="2"
+             summary="temporary error, source will produce more frames"/>
+    </enum>
+
+    <event name="cancel">
+      <description summary="indicates the frame is no longer valid">
+        If the capture failed or if the frame is no longer valid after the
+        "frame" event has been emitted, this event will be used to inform the
+        client to scrap the frame.
+
+        If the failure is temporary, the client may capture again the same
+        source. If the failure is permanent, any further attempts to capture the
+        same source will fail again.
+
+        After receiving this event, the client should destroy this object.
+      </description>
+      <arg name="reason" type="uint" enum="cancel_reason"
+           summary="indicates a reason for cancelling this frame capture"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Unreferences the frame. This request must be called as soon as its no
+        longer used.
+
+        It can be called at any time by the client. The client will still have
+        to close any FDs it has been given.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/wlr-output-management-unstable-v1.xml
+++ b/protocol/wlr-output-management-unstable-v1.xml
@@ -1,0 +1,601 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="protocol to configure output devices">
+    This protocol exposes interfaces to obtain and modify output device
+    configuration.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_manager_v1" version="4">
+    <description summary="output device configuration manager">
+      This interface is a manager that allows reading and writing the current
+      output device configuration.
+
+      Output devices that display pixels (e.g. a physical monitor or a virtual
+      output in a window) are represented as heads. Heads cannot be created nor
+      destroyed by the client, but they can be enabled or disabled and their
+      properties can be changed. Each head may have one or more available modes.
+
+      Whenever a head appears (e.g. a monitor is plugged in), it will be
+      advertised via the head event. Immediately after the output manager is
+      bound, all current heads are advertised.
+
+      Whenever a head's properties change, the relevant wlr_output_head events
+      will be sent. Not all head properties will be sent: only properties that
+      have changed need to.
+
+      Whenever a head disappears (e.g. a monitor is unplugged), a
+      wlr_output_head.finished event will be sent.
+
+      After one or more heads appear, change or disappear, the done event will
+      be sent. It carries a serial which can be used in a create_configuration
+      request to update heads properties.
+
+      The information obtained from this protocol should only be used for output
+      configuration purposes. This protocol is not designed to be a generic
+      output property advertisement protocol for regular clients. Instead,
+      protocols such as xdg-output should be used.
+    </description>
+
+    <event name="head">
+      <description summary="introduce a new head">
+        This event introduces a new head. This happens whenever a new head
+        appears (e.g. a monitor is plugged in) or after the output manager is
+        bound.
+      </description>
+      <arg name="head" type="new_id" interface="zwlr_output_head_v1"/>
+    </event>
+
+    <event name="done">
+      <description summary="sent all information about current configuration">
+        This event is sent after all information has been sent after binding to
+        the output manager object and after any subsequent changes. This applies
+        to child head and mode objects as well. In other words, this event is
+        sent whenever a head or mode is created or destroyed and whenever one of
+        their properties has been changed. Not all state is re-sent each time
+        the current configuration changes: only the actual changes are sent.
+
+        This allows changes to the output configuration to be seen as atomic,
+        even if they happen via multiple events.
+
+        A serial is sent to be used in a future create_configuration request.
+      </description>
+      <arg name="serial" type="uint" summary="current configuration serial"/>
+    </event>
+
+    <request name="create_configuration">
+      <description summary="create a new output configuration object">
+        Create a new output configuration object. This allows to update head
+        properties.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_configuration_v1"/>
+      <arg name="serial" type="uint"/>
+    </request>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for output
+        configuration changes. However the compositor may emit further events,
+        until the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+
+    <event name="finished" type="destructor">
+      <description summary="the compositor has finished with the manager">
+        This event indicates that the compositor is done sending manager events.
+        The compositor will destroy the object immediately after sending this
+        event, so it will become invalid and the client should release any
+        resources associated with it.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_output_head_v1" version="4">
+    <description summary="output device">
+      A head is an output device. The difference between a wl_output object and
+      a head is that heads are advertised even if they are turned off. A head
+      object only advertises properties and cannot be used directly to change
+      them.
+
+      A head has some read-only properties: modes, name, description and
+      physical_size. These cannot be changed by clients.
+
+      Other properties can be updated via a wlr_output_configuration object.
+
+      Properties sent via this interface are applied atomically via the
+      wlr_output_manager.done event. No guarantees are made regarding the order
+      in which properties are sent.
+    </description>
+
+    <event name="name">
+      <description summary="head name">
+        This event describes the head name.
+
+        The naming convention is compositor defined, but limited to alphanumeric
+        characters and dashes (-). Each name is unique among all wlr_output_head
+        objects, but if a wlr_output_head object is destroyed the same name may
+        be reused later. The names will also remain consistent across sessions
+        with the same hardware and software configuration.
+
+        Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+        not assume that the name is a reflection of an underlying DRM
+        connector, X11 connection, etc.
+
+        If the compositor implements the xdg-output protocol and this head is
+        enabled, the xdg_output.name event must report the same name.
+
+        The name event is sent after a wlr_output_head object is created. This
+        event is only sent once per object, and the name does not change over
+        the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="name" type="string"/>
+    </event>
+
+    <event name="description">
+      <description summary="head description">
+        This event describes a human-readable description of the head.
+
+        The description is a UTF-8 string with no convention defined for its
+        contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+        output via :1'. However, do not assume that the name is a reflection of
+        the make, model, serial of the underlying DRM connector or the display
+        name of the underlying X11 connection, etc.
+
+        If the compositor implements xdg-output and this head is enabled,
+        the xdg_output.description must report the same description.
+
+        The description event is sent after a wlr_output_head object is created.
+        This event is only sent once per object, and the description does not
+        change over the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="description" type="string"/>
+    </event>
+
+    <event name="physical_size">
+      <description summary="head physical size">
+        This event describes the physical size of the head. This event is only
+        sent if the head has a physical size (e.g. is not a projector or a
+        virtual device).
+      </description>
+      <arg name="width" type="int" summary="width in millimeters of the output"/>
+      <arg name="height" type="int" summary="height in millimeters of the output"/>
+    </event>
+
+    <event name="mode">
+      <description summary="introduce a mode">
+        This event introduces a mode for this head. It is sent once per
+        supported mode.
+      </description>
+      <arg name="mode" type="new_id" interface="zwlr_output_mode_v1"/>
+    </event>
+
+    <event name="enabled">
+      <description summary="head is enabled or disabled">
+        This event describes whether the head is enabled. A disabled head is not
+        mapped to a region of the global compositor space.
+
+        When a head is disabled, some properties (current_mode, position,
+        transform and scale) are irrelevant.
+      </description>
+      <arg name="enabled" type="int" summary="zero if disabled, non-zero if enabled"/>
+    </event>
+
+    <event name="current_mode">
+      <description summary="current mode">
+        This event describes the mode currently in use for this head. It is only
+        sent if the output is enabled.
+      </description>
+      <arg name="mode" type="object" interface="zwlr_output_mode_v1"/>
+    </event>
+
+    <event name="position">
+      <description summary="current position">
+        This events describes the position of the head in the global compositor
+        space. It is only sent if the output is enabled.
+      </description>
+      <arg name="x" type="int"
+        summary="x position within the global compositor space"/>
+      <arg name="y" type="int"
+        summary="y position within the global compositor space"/>
+    </event>
+
+    <event name="transform">
+      <description summary="current transformation">
+        This event describes the transformation currently applied to the head.
+        It is only sent if the output is enabled.
+      </description>
+      <arg name="transform" type="int" enum="wl_output.transform"/>
+    </event>
+
+    <event name="scale">
+      <description summary="current scale">
+        This events describes the scale of the head in the global compositor
+        space. It is only sent if the output is enabled.
+      </description>
+      <arg name="scale" type="fixed"/>
+    </event>
+
+    <event name="finished">
+      <description summary="the head has disappeared">
+        This event indicates that the head is no longer available. The head
+        object becomes inert. Clients should send a destroy request and release
+        any resources associated with it.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="make" since="2">
+      <description summary="head manufacturer">
+        This event describes the manufacturer of the head.
+
+        This must report the same make as the wl_output interface does in its
+        geometry event.
+
+        Together with the model and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the make of
+        the head or the definition of a make is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        It is not recommended to display the make string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="make" type="string"/>
+    </event>
+
+    <event name="model" since="2">
+      <description summary="head model">
+        This event describes the model of the head.
+
+        This must report the same model as the wl_output interface does in its
+        geometry event.
+
+        Together with the make and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the model of
+        the head or the definition of a model is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        It is not recommended to display the model string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="model" type="string"/>
+    </event>
+
+    <event name="serial_number" since="2">
+      <description summary="head serial number">
+        This event describes the serial number of the head.
+
+        Together with the make and model events the purpose is to allow clients
+        to recognize heads from previous sessions and for example load head-
+        specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the serial
+        number of the head or the definition of a serial number is not sensible
+        in the current setup. Clients can still try to identify the head by
+        available information from other events but should be aware that there
+        is an increased risk of false positives.
+
+        It is not recommended to display the serial_number string in UI to
+        users. For that the string provided by the description event should be
+        preferred.
+      </description>
+      <arg name="serial_number" type="string"/>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="destroy the head object">
+        This request indicates that the client will no longer use this head
+        object.
+      </description>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <enum name="adaptive_sync_state" since="4">
+      <entry name="disabled" value="0" summary="adaptive sync is disabled"/>
+      <entry name="enabled" value="1" summary="adaptive sync is enabled"/>
+    </enum>
+
+    <event name="adaptive_sync" since="4">
+      <description summary="current adaptive sync state">
+        This event describes whether adaptive sync is currently enabled for
+        the head or not. Adaptive sync is also known as Variable Refresh
+        Rate or VRR.
+      </description>
+      <arg name="state" type="uint" enum="adaptive_sync_state"/>
+    </event>
+  </interface>
+
+  <interface name="zwlr_output_mode_v1" version="3">
+    <description summary="output mode">
+      This object describes an output mode.
+
+      Some heads don't support output modes, in which case modes won't be
+      advertised.
+
+      Properties sent via this interface are applied atomically via the
+      wlr_output_manager.done event. No guarantees are made regarding the order
+      in which properties are sent.
+    </description>
+
+    <event name="size">
+      <description summary="mode size">
+        This event describes the mode size. The size is given in physical
+        hardware units of the output device. This is not necessarily the same as
+        the output size in the global compositor space. For instance, the output
+        may be scaled or transformed.
+      </description>
+      <arg name="width" type="int" summary="width of the mode in hardware units"/>
+      <arg name="height" type="int" summary="height of the mode in hardware units"/>
+    </event>
+
+    <event name="refresh">
+      <description summary="mode refresh rate">
+        This event describes the mode's fixed vertical refresh rate. It is only
+        sent if the mode has a fixed refresh rate.
+      </description>
+      <arg name="refresh" type="int" summary="vertical refresh rate in mHz"/>
+    </event>
+
+    <event name="preferred">
+      <description summary="mode is preferred">
+        This event advertises this mode as preferred.
+      </description>
+    </event>
+
+    <event name="finished">
+      <description summary="the mode has disappeared">
+        This event indicates that the mode is no longer available. The mode
+        object becomes inert. Clients should send a destroy request and release
+        any resources associated with it.
+      </description>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="destroy the mode object">
+        This request indicates that the client will no longer use this mode
+        object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_configuration_v1" version="4">
+    <description summary="output configuration">
+      This object is used by the client to describe a full output configuration.
+
+      First, the client needs to setup the output configuration. Each head can
+      be either enabled (and configured) or disabled. It is a protocol error to
+      send two enable_head or disable_head requests with the same head. It is a
+      protocol error to omit a head in a configuration.
+
+      Then, the client can apply or test the configuration. The compositor will
+      then reply with a succeeded, failed or cancelled event. Finally the client
+      should destroy the configuration object.
+    </description>
+
+    <enum name="error">
+      <entry name="already_configured_head" value="1"
+        summary="head has been configured twice"/>
+      <entry name="unconfigured_head" value="2"
+        summary="head has not been configured"/>
+      <entry name="already_used" value="3"
+        summary="request sent after configuration has been applied or tested"/>
+    </enum>
+
+    <request name="enable_head">
+      <description summary="enable and configure a head">
+        Enable a head. This request creates a head configuration object that can
+        be used to change the head's properties.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_configuration_head_v1"
+        summary="a new object to configure the head"/>
+      <arg name="head" type="object" interface="zwlr_output_head_v1"
+        summary="the head to be enabled"/>
+    </request>
+
+    <request name="disable_head">
+      <description summary="disable a head">
+        Disable a head.
+      </description>
+      <arg name="head" type="object" interface="zwlr_output_head_v1"
+        summary="the head to be disabled"/>
+    </request>
+
+    <request name="apply">
+      <description summary="apply the configuration">
+        Apply the new output configuration.
+
+        In case the configuration is successfully applied, there is no guarantee
+        that the new output state matches completely the requested
+        configuration. For instance, a compositor might round the scale if it
+        doesn't support fractional scaling.
+
+        After this request has been sent, the compositor must respond with an
+        succeeded, failed or cancelled event. Sending a request that isn't the
+        destructor is a protocol error.
+      </description>
+    </request>
+
+    <request name="test">
+      <description summary="test the configuration">
+        Test the new output configuration. The configuration won't be applied,
+        but will only be validated.
+
+        Even if the compositor succeeds to test a configuration, applying it may
+        fail.
+
+        After this request has been sent, the compositor must respond with an
+        succeeded, failed or cancelled event. Sending a request that isn't the
+        destructor is a protocol error.
+      </description>
+    </request>
+
+    <event name="succeeded">
+      <description summary="configuration changes succeeded">
+        Sent after the compositor has successfully applied the changes or
+        tested them.
+
+        Upon receiving this event, the client should destroy this object.
+
+        If the current configuration has changed, events to describe the changes
+        will be sent followed by a wlr_output_manager.done event.
+      </description>
+    </event>
+
+    <event name="failed">
+      <description summary="configuration changes failed">
+        Sent if the compositor rejects the changes or failed to apply them. The
+        compositor should revert any changes made by the apply request that
+        triggered this event.
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <event name="cancelled">
+      <description summary="configuration has been cancelled">
+        Sent if the compositor cancels the configuration because the state of an
+        output changed and the client has outdated information (e.g. after an
+        output has been hotplugged).
+
+        The client can create a new configuration with a newer serial and try
+        again.
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the output configuration">
+        Using this request a client can tell the compositor that it is not going
+        to use the configuration object anymore. Any changes to the outputs
+        that have not been applied will be discarded.
+
+        This request also destroys wlr_output_configuration_head objects created
+        via this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_configuration_head_v1" version="4">
+    <description summary="head configuration">
+      This object is used by the client to update a single head's configuration.
+
+      It is a protocol error to set the same property twice.
+    </description>
+
+    <enum name="error">
+      <entry name="already_set" value="1" summary="property has already been set"/>
+      <entry name="invalid_mode" value="2" summary="mode doesn't belong to head"/>
+      <entry name="invalid_custom_mode" value="3" summary="mode is invalid"/>
+      <entry name="invalid_transform" value="4" summary="transform value outside enum"/>
+      <entry name="invalid_scale" value="5" summary="scale negative or zero"/>
+      <entry name="invalid_adaptive_sync_state" value="6" since="4"
+        summary="invalid enum value used in the set_adaptive_sync request"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="set the mode">
+        This request sets the head's mode.
+      </description>
+      <arg name="mode" type="object" interface="zwlr_output_mode_v1"/>
+    </request>
+
+    <request name="set_custom_mode">
+      <description summary="set a custom mode">
+        This request assigns a custom mode to the head. The size is given in
+        physical hardware units of the output device. If set to zero, the
+        refresh rate is unspecified.
+
+        It is a protocol error to set both a mode and a custom mode.
+      </description>
+      <arg name="width" type="int" summary="width of the mode in hardware units"/>
+      <arg name="height" type="int" summary="height of the mode in hardware units"/>
+      <arg name="refresh" type="int" summary="vertical refresh rate in mHz or zero"/>
+    </request>
+
+    <request name="set_position">
+      <description summary="set the position">
+        This request sets the head's position in the global compositor space.
+      </description>
+      <arg name="x" type="int" summary="x position in the global compositor space"/>
+      <arg name="y" type="int" summary="y position in the global compositor space"/>
+    </request>
+
+    <request name="set_transform">
+      <description summary="set the transform">
+        This request sets the head's transform.
+      </description>
+      <arg name="transform" type="int" enum="wl_output.transform"/>
+    </request>
+
+    <request name="set_scale">
+      <description summary="set the scale">
+        This request sets the head's scale.
+      </description>
+      <arg name="scale" type="fixed"/>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <request name="set_adaptive_sync" since="4">
+      <description summary="enable/disable adaptive sync">
+        This request enables/disables adaptive sync. Adaptive sync is also
+        known as Variable Refresh Rate or VRR.
+      </description>
+      <arg name="state" type="uint" enum="zwlr_output_head_v1.adaptive_sync_state"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/wlr-screencopy-unstable-v1.xml
+++ b/protocol/wlr-screencopy-unstable-v1.xml
@@ -38,7 +38,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_screencopy_manager_v1" version="2">
+  <interface name="zwlr_screencopy_manager_v1" version="3">
     <description summary="manager to inform clients and begin capturing">
       This object is a manager which offers requests to start capturing from a
       source.
@@ -80,13 +80,18 @@
     </request>
   </interface>
 
-  <interface name="zwlr_screencopy_frame_v1" version="2">
+  <interface name="zwlr_screencopy_frame_v1" version="3">
     <description summary="a frame ready for copy">
       This object represents a single frame.
 
-      When created, a "buffer" event will be sent. The client will then be able
-      to send a "copy" request. If the capture is successful, the compositor
-      will send a "flags" followed by a "ready" event.
+      When created, a series of buffer events will be sent, each representing a
+      supported buffer type. The "buffer_done" event is sent afterwards to
+      indicate that all supported buffer types have been enumerated. The client
+      will then be able to send a "copy" request. If the capture is successful,
+      the compositor will send a "flags" followed by a "ready" event.
+
+      For objects version 2 or lower, wl_shm buffers are always supported, ie.
+      the "buffer" event is guaranteed to be sent.
 
       If the capture failed, the "failed" event is sent. This can happen anytime
       before the "ready" event.
@@ -96,14 +101,12 @@
     </description>
 
     <event name="buffer">
-      <description summary="buffer information">
-        Provides information about the frame's buffer. This event is sent once
-        as soon as the frame is created.
-
-        The client should then create a buffer with the provided attributes, and
-        send a "copy" request.
+      <description summary="wl_shm buffer information">
+        Provides information about wl_shm buffer parameters that need to be
+        used for this frame. This event is sent once after the frame is created
+        if wl_shm buffers are supported.
       </description>
-      <arg name="format" type="uint" summary="buffer format"/>
+      <arg name="format" type="uint" enum="wl_shm.format" summary="buffer format"/>
       <arg name="width" type="uint" summary="buffer width"/>
       <arg name="height" type="uint" summary="buffer height"/>
       <arg name="stride" type="uint" summary="buffer stride"/>
@@ -112,8 +115,9 @@
     <request name="copy">
       <description summary="copy the frame">
         Copy the frame to the supplied buffer. The buffer must have a the
-        correct size, see zwlr_screencopy_frame_v1.buffer. The buffer needs to
-        have a supported format.
+        correct size, see zwlr_screencopy_frame_v1.buffer and
+        zwlr_screencopy_frame_v1.linux_dmabuf. The buffer needs to have a
+        supported format.
 
         If the frame is successfully copied, a "flags" and a "ready" events are
         sent. Otherwise, a "failed" event is sent.
@@ -202,6 +206,27 @@
       <arg name="y" type="uint" summary="damaged y coordinates"/>
       <arg name="width" type="uint" summary="current width"/>
       <arg name="height" type="uint" summary="current height"/>
+    </event>
+
+    <!-- Version 3 additions -->
+    <event name="linux_dmabuf" since="3">
+      <description summary="linux-dmabuf buffer information">
+        Provides information about linux-dmabuf buffer parameters that need to
+        be used for this frame. This event is sent once after the frame is
+        created if linux-dmabuf buffers are supported.
+      </description>
+      <arg name="format" type="uint" summary="fourcc pixel format"/>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+    </event>
+
+    <event name="buffer_done" since="3">
+      <description summary="all buffer types reported">
+        This event is sent once after all buffer events have been sent.
+
+        The client should proceed to create a buffer of one of the supported
+        types, and send a "copy" request.
+      </description>
     </event>
   </interface>
 </protocol>

--- a/src/modules/screen.c
+++ b/src/modules/screen.c
@@ -105,7 +105,10 @@ int rgb_frame_brightness(const uint8_t *data, const int width, const int height,
     r = (double)r / area;
     g = (double)g / area;
     b = (double)b / area;
-    return 0.299 * r + 0.587 * g + 0.114 * b;
+    /* return 0.299 * r + 0.587 * g + 0.114 * b; */
+    /* https://en.wikipedia.org/wiki/Rec._709#luma_coefficients */
+    /* https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf */
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 static int method_getbrightness(sd_bus_message* m, void* userdata, sd_bus_error* ret_error) {

--- a/src/modules/screen_plugins/wl.c
+++ b/src/modules/screen_plugins/wl.c
@@ -1,200 +1,330 @@
 #include "screen.h"
 #include "wl_utils.h"
-#include "wlr-screencopy-unstable-v1-client-protocol.h"
-
-static struct wl_buffer *create_shm_buffer(enum wl_shm_format fmt,
-        int width, int height, int stride, void **data_out);
-static void frame_handle_buffer(void *tt, struct zwlr_screencopy_frame_v1 *frame, uint32_t format,
-    uint32_t width, uint32_t height, uint32_t stride);
-static void frame_handle_flags(void*tt, struct zwlr_screencopy_frame_v1 *frame, uint32_t flags);
-static void frame_handle_ready(void *tt, struct zwlr_screencopy_frame_v1 *frame,
-    uint32_t tv_sec_hi, uint32_t tv_sec_low, uint32_t tv_nsec);
-static void frame_handle_failed(void *tt, struct zwlr_screencopy_frame_v1 *frame);
-static void handle_global(void *data, struct wl_registry *registry,
-        uint32_t name, const char *interface, uint32_t version);
-static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name);
-static void dtor(void);
-
-static struct {
-    struct wl_buffer *wl_buffer;
-    void *data;
-    enum wl_shm_format format;
-    int width, height, stride;
-    bool y_invert;
-} buffer;
 
 SCREEN("Wl");
 
-static struct zwlr_screencopy_manager_v1 *screencopy_manager;
-static struct wl_output *output;
-static struct wl_shm *shm;
-static struct wl_registry *registry;
-static struct zwlr_screencopy_frame_v1 *frame;
-static bool buffer_copy_done;
-static bool buffer_copy_err;
-
-static const struct zwlr_screencopy_frame_v1_listener frame_listener = {
-    .buffer = frame_handle_buffer,
-    .flags = frame_handle_flags,
-    .ready = frame_handle_ready,
-    .failed = frame_handle_failed,
-};
-
-static const struct wl_registry_listener registry_listener = {
-    .global = handle_global,
-    .global_remove = handle_global_remove,
-};
-
-static int get_frame_brightness(const char *id, const char *env) {
-    struct wl_display *display = fetch_wl_display(id, env);
-    if (display == NULL) {
-        return WRONG_PLUGIN;
-    }
-    
-    int ret = UNSUPPORTED;
-
-    registry = wl_display_get_registry(display);
-    wl_registry_add_listener(registry, &registry_listener, NULL);
-    wl_display_roundtrip(display);
-    
-    if (screencopy_manager == NULL) {
-        ret = COMPOSITOR_NO_PROTOCOL;
-        goto err;
-    }
-    if (shm == NULL) {
-        fprintf(stderr, "compositor is missing wl_shm\n");
-        ret = COMPOSITOR_NO_PROTOCOL;
-        goto err;
-    }
-    if (output == NULL) {
-        fprintf(stderr, "no outputs available\n");
-        goto err;
-    }
-    
-    frame = zwlr_screencopy_manager_v1_capture_output(screencopy_manager, 0, output);
-    zwlr_screencopy_frame_v1_add_listener(frame, &frame_listener, NULL);
-    
-    while (!buffer_copy_done && !buffer_copy_err && wl_display_dispatch(display) != -1) {
-        // This space is intentionally left blank
-    }
-    
-    ret = -EIO;
-    if (buffer_copy_done) {
-        ret = rgb_frame_brightness(buffer.data, buffer.width, buffer.height, buffer.stride);
-    }
-    
-err:
-    dtor();
-    return ret;
-}
-
-static struct wl_buffer *create_shm_buffer(enum wl_shm_format fmt,
-        int width, int height, int stride, void **data_out) {
-    
-    const int size = stride * height;
-
+struct cl_buffer *create_shm_buffer(struct wl_shm *shm,
+                                    enum wl_shm_format format, int width,
+                                    int height, int stride, int size) {
     int fd = create_anonymous_file(size, "clightd-screen-wlr");
     if (fd < 0) {
         fprintf(stderr, "creating a buffer file for %d B failed: %m\n", size);
         return NULL;
     }
-
     void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (data == MAP_FAILED) {
         fprintf(stderr, "mmap failed: %m\n");
         close(fd);
         return NULL;
     }
-
     struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
-    close(fd);
-    struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height,
-        stride, fmt);
+    struct wl_buffer *wl_buffer =
+        wl_shm_pool_create_buffer(pool, 0, width, height, stride, format);
     wl_shm_pool_destroy(pool);
-
-    *data_out = data;
+    close(fd);
+    struct cl_buffer *buffer = calloc(1, sizeof(struct cl_buffer));
+    buffer->wl_buffer = wl_buffer;
+    buffer->shm_data = data;
     return buffer;
 }
-
-static void frame_handle_buffer(void *tt, struct zwlr_screencopy_frame_v1 *frame, uint32_t format,
-    uint32_t width, uint32_t height, uint32_t stride) {
-
-    buffer.format = format;
-    buffer.width = width;
-    buffer.height = height;
-    buffer.stride = stride;
-    buffer.wl_buffer = create_shm_buffer(format, width, height, stride, &buffer.data);
-    if (buffer.wl_buffer == NULL) {
+static void frame_handle_buffer(void *data,
+                                struct zwlr_screencopy_frame_v1 *frame,
+                                enum wl_shm_format format, uint32_t width,
+                                uint32_t height, uint32_t stride) {
+    struct cl_output *output = (struct cl_output *)data;
+    output->frame->shm_format = format;
+    output->frame->width = width;
+    output->frame->height = height;
+    output->frame->stride = stride;
+    output->frame->size = stride * height;
+}
+static void frame_handle_ready(void *data,
+                               struct zwlr_screencopy_frame_v1 *frame,
+                               uint32_t tv_sec_hi, uint32_t tv_sec_low,
+                               uint32_t tv_nsec) {
+    struct cl_output *output = (struct cl_output *)data;
+    ++output->frame->copy_done;
+}
+static void frame_handle_failed(void *data,
+                                struct zwlr_screencopy_frame_v1 *frame) {
+    struct cl_output *output = (struct cl_output *)data;
+    fprintf(stderr, "Failed to copy frame\n");
+    ++output->frame->copy_err;
+}
+static void frame_handle_buffer_done(void *data,
+                                     struct zwlr_screencopy_frame_v1 *frame) {
+    struct cl_output *output = (struct cl_output *)data;
+    output->buffer = create_shm_buffer(
+        output->display->shm, output->frame->shm_format, output->frame->width,
+        output->frame->height, output->frame->stride, output->frame->size);
+    if (output->buffer == NULL) {
         fprintf(stderr, "failed to create buffer\n");
-        buffer_copy_err = true;
+        ++output->frame->copy_err;
     } else {
-        zwlr_screencopy_frame_v1_copy(frame, buffer.wl_buffer);
+        zwlr_screencopy_frame_v1_copy(output->screencopy_frame,
+                                      output->buffer->wl_buffer);
     }
 }
-
-static void frame_handle_flags(void*tt, struct zwlr_screencopy_frame_v1 *frame, uint32_t flags) {
-    buffer.y_invert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
+static const struct zwlr_screencopy_frame_v1_listener
+    screencopy_frame_listener = {
+        .buffer = frame_handle_buffer,
+        .flags = noop,
+        .ready = frame_handle_ready,
+        .failed = frame_handle_failed,
+        .buffer_done = frame_handle_buffer_done,
+        .linux_dmabuf = noop,
+};
+static void frame_start(void *data,
+                        struct zwlr_export_dmabuf_frame_v1 *zwlr_frame,
+                        uint32_t width, uint32_t height, uint32_t offset_x,
+                        uint32_t offset_y, uint32_t buffer_flags,
+                        uint32_t flags, uint32_t format, uint32_t mod_high,
+                        uint32_t mod_low, uint32_t num_objects) {
+    struct cl_output *output = (struct cl_output *)data;
+    struct cl_buffer *buffer = calloc(1, sizeof(struct cl_buffer));
+    output->params = zwp_linux_dmabuf_v1_create_params(output->display->dmabuf);
+    output->buffer = buffer;
+    output->frame->width = width;
+    output->frame->height = height;
+    output->frame->buf_flags = flags;
+    output->frame->dma_format = format;
+    output->frame->mod_hi = mod_high;
+    output->frame->mod_lo = mod_low;
+    output->frame->num_objects = num_objects;
 }
-
-static void frame_handle_ready(void *tt, struct zwlr_screencopy_frame_v1 *frame,
-    uint32_t tv_sec_hi, uint32_t tv_sec_low, uint32_t tv_nsec) {
-    buffer_copy_done = true;
+static void frame_object(void *data, struct zwlr_export_dmabuf_frame_v1 *frame,
+                         uint32_t index, int32_t fd, uint32_t size,
+                         uint32_t offset, uint32_t stride,
+                         uint32_t plane_index) {
+    struct cl_output *output = (struct cl_output *)data;
+    output->buffer->fds[plane_index] = fd;
+    output->buffer->sizes[plane_index] = size;
+    output->buffer->offsets[plane_index] = offset;
+    output->buffer->strides[plane_index] = stride;
+    void *dma_data = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                          output->frame->buf_flags, fd, 0);
+    if (data == MAP_FAILED) {
+        fprintf(stderr, "mmap failed: \n");
+        close(fd);
+    }
+    output->buffer->dma_data[plane_index] = dma_data;
 }
-
-static void frame_handle_failed(void *tt, struct zwlr_screencopy_frame_v1 *frame) {
-    fprintf(stderr, "failed to copy frame\n");
-    buffer_copy_err = true;
+static void frame_ready(void *data, struct zwlr_export_dmabuf_frame_v1 *frame,
+                        uint32_t tv_sec_hi, uint32_t tv_sec_lo,
+                        uint32_t tv_nsec) {
+    struct cl_output *output = (struct cl_output *)data;
+    for (int i = 0; i < output->frame->num_objects; ++i) {
+        zwp_linux_buffer_params_v1_add(
+            output->params, output->buffer->fds[i], i,
+            output->buffer->offsets[i], output->buffer->strides[i],
+            output->frame->mod_hi, output->frame->mod_lo);
+    }
+    output->buffer->wl_buffer = zwp_linux_buffer_params_v1_create_immed(
+        output->params, output->frame->width, output->frame->height,
+        output->frame->dma_format, 0);
+    zwp_linux_buffer_params_v1_destroy(output->params);
+    ++output->frame->copy_done;
 }
-
+static void frame_cancel(void *data, struct zwlr_export_dmabuf_frame_v1 *frame,
+                         uint32_t reason) {
+    struct cl_output *output = (struct cl_output *)data;
+    ++output->frame->copy_err;
+}
+static const struct zwlr_export_dmabuf_frame_v1_listener dmabuf_frame_listener =
+    {
+        .frame = frame_start,
+        .object = frame_object,
+        .ready = frame_ready,
+        .cancel = frame_cancel,
+};
+static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {
+    .format = noop,
+    .modifier = noop,
+};
+static void output_handle_name(void *data, struct wl_output *wl_output,
+                               const char *name) {
+    struct cl_output *output = (struct cl_output *)data;
+    if (output->name != NULL)
+        free(output->name);
+    output->name = strdup(name);
+};
+static const struct wl_output_listener wl_output_listener = {
+    .name = output_handle_name,
+    .geometry = noop,
+    .mode = noop,
+    .scale = noop,
+    .description = noop,
+    .done = noop,
+};
 static void handle_global(void *data, struct wl_registry *registry,
-        uint32_t name, const char *interface, uint32_t version) {
-
-    // we just use first output
-    if (strcmp(interface, wl_output_interface.name) == 0 && !output) {
-        output = wl_registry_bind(registry, name, &wl_output_interface, 1);
-    }
-    else if (strcmp(interface, wl_shm_interface.name) == 0) {
-        shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
-    }
-    else if (strcmp(interface, zwlr_screencopy_manager_v1_interface.name) == 0) {
-        screencopy_manager = wl_registry_bind(registry, name, &zwlr_screencopy_manager_v1_interface, 2);
+                          uint32_t name, const char *interface,
+                          uint32_t version) {
+    struct cl_display *display = (struct cl_display *)data;
+    struct cl_output *output = calloc(1, sizeof(struct cl_output));
+    output->display = display;
+    if (strcmp(interface, wl_output_interface.name) == 0) {
+        output->wl_output =
+            wl_registry_bind(registry, name, &wl_output_interface, 4);
+        wl_output_add_listener(output->wl_output, &wl_output_listener, output);
+        output->name = NULL;
+        wl_list_insert(&display->outputs, &output->link);
+    } else if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
+        display->dmabuf =
+            wl_registry_bind(registry, name, &zwp_linux_dmabuf_v1_interface, 4);
+    } else if (strcmp(interface,
+                      zwlr_export_dmabuf_manager_v1_interface.name) == 0) {
+        display->dmabuf_manager = wl_registry_bind(
+            registry, name, &zwlr_export_dmabuf_manager_v1_interface, 1);
+    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
+        display->shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+    } else if (strcmp(interface, zwlr_screencopy_manager_v1_interface.name) ==
+               0) {
+        display->screencopy_manager = wl_registry_bind(
+            registry, name, &zwlr_screencopy_manager_v1_interface, 3);
     }
 }
-
-static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name) {
-    
+static const struct wl_registry_listener registry_listener = {
+    .global = handle_global,
+    .global_remove = noop,
+};
+static void wl_cleanup(struct cl_display *display) {
+    struct cl_output *output;
+    struct cl_output *tmp_output;
+    wl_list_for_each_safe(output, tmp_output, &display->outputs, link) {
+        output->frame->copy_done = false;
+        output->frame->copy_err = false;
+        if (output->dmabuf_frame != NULL) {
+            zwlr_export_dmabuf_frame_v1_destroy(output->dmabuf_frame);
+        }
+        if (output->screencopy_frame != NULL) {
+            zwlr_screencopy_frame_v1_destroy(output->screencopy_frame);
+        }
+        if (output->buffer->dma_data[0]) {
+            for (int i = 0; i < output->frame->num_objects; ++i) {
+                if (output->buffer->dma_data[i]) {
+                    munmap(output->buffer->dma_data[i],
+                           output->buffer->sizes[i]);
+                }
+            }
+        }
+        if (output->buffer->shm_data) {
+            munmap(output->buffer->shm_data, output->frame->size);
+        }
+        if (output->buffer->wl_buffer) {
+            wl_buffer_destroy(output->buffer->wl_buffer);
+        }
+        free(output->buffer);
+        wl_output_destroy(output->wl_output);
+        wl_list_remove(&output->link);
+        free(output->name);
+        free(output);
+    }
+    if (display->wl_registry) {
+        wl_registry_destroy(display->wl_registry);
+    }
+    if (display->dmabuf_manager) {
+        zwlr_export_dmabuf_manager_v1_destroy(display->dmabuf_manager);
+    }
+    if (display->screencopy_manager) {
+        zwlr_screencopy_manager_v1_destroy(display->screencopy_manager);
+    }
+    wl_display_flush(display->wl_display);
+    wl_display_disconnect(display->wl_display);
 }
+static int get_frame_brightness(const char *id, const char *env) {
+    struct cl_display display = {};
+    struct cl_output *output;
+    int ret = 0;
 
-static void dtor(void) {
-    buffer_copy_done = false;
-    buffer_copy_err = false;
-    
-    /* Free everything */
-    if (buffer.wl_buffer) {
-        wl_buffer_destroy(buffer.wl_buffer);
-        buffer.wl_buffer = NULL;
+    char *socket_file;
+    int len = snprintf(NULL, 0, "%s/%s", env, id);
+    if (len < 0) {
+        perror("snprintf failed");
+        return EXIT_FAILURE;
     }
-    if (buffer.data) {
-        munmap(buffer.data, (size_t)buffer.height * buffer.stride);
-        buffer.data = NULL;
+    socket_file = malloc(len + 1);
+    snprintf(socket_file, len + 1, "%s/%s", env, id);
+    /* fprintf(stderr, "Using wayland socket: %s\n", socket_file); */
+    display.wl_display = wl_display_connect(socket_file);
+    free(socket_file);
+    if (display.wl_display == NULL) {
+        fprintf(stderr, "display error\n");
+        ret = WRONG_PLUGIN;
+        goto err;
     }
-    if (output) {
-        wl_output_destroy(output);
-        output = NULL;
+    wl_list_init(&display.outputs);
+    display.wl_registry = wl_display_get_registry(display.wl_display);
+    wl_registry_add_listener(display.wl_registry, &registry_listener, &display);
+    wl_display_roundtrip(display.wl_display);
+    wl_display_roundtrip(display.wl_display);
+
+    if (!display.dmabuf && display.shm == NULL) {
+        fprintf(stderr, "Compositor is missing wl_shm\n");
+        ret = COMPOSITOR_NO_PROTOCOL;
+        goto err;
     }
-     if (registry) {
-        wl_registry_destroy(registry);
+    if (!display.dmabuf && display.screencopy_manager == NULL) {
+        fprintf(stderr, "Compositor is screencopy manager\n");
+        ret = COMPOSITOR_NO_PROTOCOL;
+        goto err;
     }
-    if (frame) {
-        zwlr_screencopy_frame_v1_destroy(frame);
+    if (wl_list_empty(&display.outputs)) {
+        fprintf(stderr, "No outputs available\n");
+        ret = UNSUPPORTED;
+        goto err;
     }
-    if (shm) {
-        wl_shm_destroy(shm);
+    int sum = 0;
+    wl_list_for_each(output, &display.outputs, link) {
+        struct cl_frame *frame = calloc(1, sizeof(struct cl_frame));
+        output->frame = frame;
+        if (display.dmabuf) {
+            output->dmabuf_frame = zwlr_export_dmabuf_manager_v1_capture_output(
+                display.dmabuf_manager, 0, output->wl_output);
+            zwlr_export_dmabuf_frame_v1_add_listener(
+                output->dmabuf_frame, &dmabuf_frame_listener, output);
+        } else {
+            output->screencopy_frame =
+                zwlr_screencopy_manager_v1_capture_output(
+                    display.screencopy_manager, 0, output->wl_output);
+            zwlr_screencopy_frame_v1_add_listener(
+                output->screencopy_frame, &screencopy_frame_listener, output);
+        }
+        while (!output->frame->copy_done && !output->frame->copy_err &&
+               wl_display_dispatch(display.wl_display) != -1) {
+            // This space is intentionally left blank
+        }
+        if (output->frame->copy_done) {
+            if (output->buffer->dma_data[0]) {
+                /* fprintf(stderr, "using dma buffers\n"); */
+                output->frame->brightness = rgb_frame_brightness(
+                    output->buffer->dma_data[0], output->frame->width,
+                    output->frame->height, output->buffer->strides[0]);
+            } else {
+                /* fprintf(stderr, "using shm buffers\n"); */
+                output->frame->brightness = rgb_frame_brightness(
+                    output->buffer->shm_data, output->frame->width,
+                    output->frame->height, output->frame->stride);
+            }
+            /* fprintf(stderr, "Output: %s Brightness: %d Percent: %.02f%%\n",
+             */
+            /*         output->name, output->frame->brightness, */
+            /*         (output->frame->brightness / 255.0) * 100.0); */
+            sum += output->frame->brightness;
+        }
+        if (output->frame->num_objects) {
+            for (int i = 0; i < output->frame->num_objects; ++i) {
+                close(output->buffer->fds[i]);
+                output->buffer->fds[i] = -1;
+            }
+        }
     }
-    if (screencopy_manager) {
-        zwlr_screencopy_manager_v1_destroy(screencopy_manager);
+    if (sum > 0) {
+        sum = sum / wl_list_length(&display.outputs);
     }
-     // NOTE: dpy is disconnected on program exit to workaround
-    // gamma protocol limitation that resets gamma as soon as display is disconnected.
-    // See wl_utils.c
+err:
+    wl_cleanup(&display);
+    if (ret != 0) {
+        return ret;
+    }
+    return sum;
 }

--- a/src/utils/wl_utils.c
+++ b/src/utils/wl_utils.c
@@ -13,6 +13,9 @@ typedef struct {
     char *env;
 } wl_info;
 
+void noop() {
+}
+
 static void wl_info_dtor(void *data);
 
 static map_t *wl_map;

--- a/src/utils/wl_utils.h
+++ b/src/utils/wl_utils.h
@@ -1,7 +1,79 @@
 #pragma once
 
-#include <wayland-client.h>
+#include "wlr-output-management-unstable-v1-client-protocol.h"
+#include <stdbool.h>
 #include <sys/mman.h>
+#ifdef SCREEN_PRESENT
+#include "linux-dmabuf-unstable-v1-client-protocol.h"
+#include "wlr-export-dmabuf-unstable-v1-client-protocol.h"
+#include "wlr-screencopy-unstable-v1-client-protocol.h"
+#include <assert.h>
+#include <xf86drm.h>
+#endif
 
 struct wl_display *fetch_wl_display(const char *display, const char *env);
 int create_anonymous_file(off_t size, const char *filename);
+void noop();
+
+struct cl_display {
+    struct wl_display *wl_display;
+    struct wl_registry *wl_registry;
+    struct zwlr_output_manager_v1 *output_manager;
+    struct wl_list outputs;
+#ifdef SCREEN_PRESENT
+    struct zwp_linux_dmabuf_v1 *dmabuf;
+    struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback;
+    struct zwlr_export_dmabuf_manager_v1 *dmabuf_manager;
+    struct wl_shm *shm;
+    struct zwlr_screencopy_manager_v1 *screencopy_manager;
+    bool have_linux_dmabuf;
+    bool try_linux_dmabuf;
+#endif
+};
+
+#define WLR_DMABUF_MAX_PLANES 4
+
+struct cl_buffer {
+    struct wl_buffer *wl_buffer;
+#ifdef SCREEN_PRESENT
+    struct zwp_linux_buffer_params_v1 *params;
+    void *shm_data;
+    uint8_t *dma_data[WLR_DMABUF_MAX_PLANES];
+    uint32_t sizes[WLR_DMABUF_MAX_PLANES];
+    uint32_t strides[WLR_DMABUF_MAX_PLANES];
+    uint32_t offsets[WLR_DMABUF_MAX_PLANES];
+    int fds[WLR_DMABUF_MAX_PLANES];
+#endif
+};
+
+struct cl_frame {
+#ifdef SCREEN_PRESENT
+    int32_t width, height, stride, size, buf_flags, dma_format;
+    enum wl_shm_format shm_format;
+    uint32_t mod_hi;
+    uint32_t mod_lo;
+    uint32_t num_objects;
+
+    int brightness;
+
+    bool copy_done;
+    bool copy_err;
+#endif
+};
+
+struct cl_output {
+    struct cl_display *display;
+    struct wl_output *wl_output;
+    struct wl_list link;
+    char *name;
+
+    struct cl_buffer *buffer;
+
+#ifdef SCREEN_PRESENT
+    dev_t main_device_id;
+    struct cl_frame *frame;
+    struct zwp_linux_buffer_params_v1 *params;
+    struct zwlr_export_dmabuf_frame_v1 *dmabuf_frame;
+    struct zwlr_screencopy_frame_v1 *screencopy_frame;
+#endif
+};


### PR DESCRIPTION
This commit is rather large but provides two main features:

- It updates the wayland screen implementation to use dmabufs with shm
  buffers as a fallback.
- Providing an ability to get screen brightness per output. Currently,
  it averages the brightness to be sent from a `get_frame_brightness`
  call, but can be useful if we allow for per-output screen brightness
  modifications.

In order to accomplish the above the following protocols
updated/included:
- wlr-screencopy-unstable-v1 (updated to v3)
- wlr-output-management-unstable-v1
- wlr-export-dmabuf-unstable-v1
- linux-dmabuf-unstable-v1

I also took the liberty to attempt to centralize some structs that could
be reused for the other wayland modules `cl_display`, `cl_buffer`,
`cl_frame`, & `cl_output`. I haven't looked into incorporating them but
I've included it in case you find it useful. If not, I can move them
back to the `screen/wl.c` file.