### PR TITLE
new(src,protocol): implement wlr dpms protocol under `Wl` obj path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,25 +79,28 @@ macro(optional_dep name modules description)
         set(extra_macro_args ${ARGN})
         list(LENGTH extra_macro_args num_extra_args)
         if (${num_extra_args} GREATER 0)
-            # Generate protocol source and header files
-            # and add them to target_sources + target_include_directories(
-            list(GET extra_macro_args 0 wl_proto)
-            WAYLAND_ADD_PROTOCOL_CLIENT(${wl_proto})
-            
             # Add various plugins
-            list(GET extra_macro_args 1 src_proto)
+            list(GET extra_macro_args 0 src_proto)
             file(GLOB EXTRA_SRCS ${src_proto}/*)
             target_sources(${PROJECT_NAME} PRIVATE ${EXTRA_SRCS})
+            
+            # Remove the item so that we can cycle on wl protocol only
+            list(REMOVE_ITEM extra_macro_args "${src_proto}")
+            
+            # Generate protocol source and header files
+            # and add them to target_sources + target_include_directories
+            foreach(wl_proto ${extra_macro_args})
+                WAYLAND_ADD_PROTOCOL_CLIENT(${wl_proto})
+            endforeach()
         endif()
     else()
         message(STATUS "${name} support disabled")
     endif()
 endmacro()
 
-optional_dep(GAMMA "x11;xrandr;libdrm;wayland-client" "Gamma correction" protocol/wlr-gamma-control-unstable-v1.xml src/modules/gamma_plugins)
-optional_dep(DPMS "x11;xext;libdrm;wayland-client" "DPMS" protocol/org_kde_kwin_dpms.xml src/modules/dpms_plugins)
-optional_dep(SCREEN "x11" "screen emitted brightness" protocol/wlr-screencopy-unstable-v1.xml src/modules/screen_plugins)
-optional_dep(SCREEN "x11" "screen emitted brightness" protocol/wlr-output-management-unstable-v1.xml src/modules/screen_plugins)
+optional_dep(GAMMA "x11;xrandr;libdrm;wayland-client" "Gamma correction" src/modules/gamma_plugins protocol/wlr-gamma-control-unstable-v1.xml)
+optional_dep(DPMS "x11;xext;libdrm;wayland-client" "DPMS" src/modules/dpms_plugins protocol/org_kde_kwin_dpms.xml;protocol/wlr-output-power-management-unstable-v1.xml)
+optional_dep(SCREEN "x11" "screen emitted brightness" src/modules/screen_plugins protocol/wlr-screencopy-unstable-v1.xml;protocol/wlr-output-management-unstable-v1.xml )
 optional_dep(DDC "ddcutil>=0.9.5" "external monitor backlight")
 optional_dep(YOCTOLIGHT "libusb-1.0" "Yoctolight usb als devices support")
 optional_dep(PIPEWIRE "libpipewire-0.3" "Enable pipewire camera sensor support")

--- a/TODO.md
+++ b/TODO.md
@@ -23,9 +23,11 @@
 - [x] give higher priority to wlroots protocol (in respect to kwin protocol)
 - [x] rename kwin protocol to `kwin_wl` 
 - [x] `wl` is instead wlroots (like all other plugins)
+- [x] fix KWin_wl
 
 ### Generic
 - [x] port CI to gh actions
+- [ ] download wayland protocols from https://wayland.app/protocols instead of embedding them?
 
 ## 5.x
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,12 @@
 - [x] fix `rgb_frame_brightness` impl
 - [x] fix xorg impl
 
+### Dpms
+- [x] implement wlroots DPMS protocol (wlr-output-power-management-unstable-v1.xml)
+- [x] give higher priority to wlroots protocol (in respect to kwin protocol)
+- [x] rename kwin protocol to `kwin_wl` 
+- [x] `wl` is instead wlroots (like all other plugins)
+
 ### Generic
 - [x] port CI to gh actions
 

--- a/protocol/wlr-output-power-management-unstable-v1.xml
+++ b/protocol/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+    <copyright>
+        Copyright © 2019 Purism SPC
+        
+        Permission is hereby granted, free of charge, to any person obtaining a
+        copy of this software and associated documentation files (the "Software"),
+        to deal in the Software without restriction, including without limitation
+        the rights to use, copy, modify, merge, publish, distribute, sublicense,
+        and/or sell copies of the Software, and to permit persons to whom the
+        Software is furnished to do so, subject to the following conditions:
+        
+        The above copyright notice and this permission notice (including the next
+        paragraph) shall be included in all copies or substantial portions of the
+        Software.
+        
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+        DEALINGS IN THE SOFTWARE.
+    </copyright>
+    
+    <description summary="Control power management modes of outputs">
+        This protocol allows clients to control power management modes
+        of outputs that are currently part of the compositor space. The
+        intent is to allow special clients like desktop shells to power
+        down outputs when the system is idle.
+        
+        To modify outputs not currently part of the compositor space see
+        wlr-output-management.
+        
+        Warning! The protocol described in this file is experimental and
+        backward incompatible changes may be made. Backward compatible changes
+        may be added together with the corresponding interface version bump.
+        Backward incompatible changes are done by bumping the version number in
+        the protocol and interface names and resetting the interface version.
+        Once the protocol is to be declared stable, the 'z' prefix and the
+        version number in the protocol and interface names are removed and the
+        interface version number is reset.
+    </description>
+    
+    <interface name="zwlr_output_power_manager_v1" version="1">
+        <description summary="manager to create per-output power management">
+            This interface is a manager that allows creating per-output power
+            management mode controls.
+        </description>
+        
+        <request name="get_output_power">
+            <description summary="get a power management for an output">
+                Create an output power management mode control that can be used to
+                adjust the power management mode for a given output.
+            </description>
+            <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+            <arg name="output" type="object" interface="wl_output"/>
+        </request>
+        
+        <request name="destroy" type="destructor">
+            <description summary="destroy the manager">
+                All objects created by the manager will still remain valid, until their
+                appropriate destroy request has been called.
+            </description>
+        </request>
+    </interface>
+    
+    <interface name="zwlr_output_power_v1" version="1">
+        <description summary="adjust power management mode for an output">
+            This object offers requests to set the power management mode of
+            an output.
+        </description>
+        
+        <enum name="mode">
+            <entry name="off" value="0"
+                   summary="Output is turned off."/>
+            <entry name="on" value="1"
+                   summary="Output is turned on, no power saving"/>
+            </enum>
+            
+            <enum name="error">
+                <entry name="invalid_mode" value="1" summary="nonexistent power save mode"/>
+            </enum>
+            
+            <request name="set_mode">
+                <description summary="Set an outputs power save mode">
+                    Set an output's power save mode to the given mode. The mode change
+                    is effective immediately. If the output does not support the given
+                    mode a failed event is sent.
+                </description>
+                <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+            </request>
+            
+            <event name="mode">
+                <description summary="Report a power management mode change">
+                    Report the power management mode change of an output.
+                    
+                    The mode event is sent after an output changed its power
+                    management mode. The reason can be a client using set_mode or the
+                    compositor deciding to change an output's mode.
+                    This event is also sent immediately when the object is created
+                    so the client is informed about the current power management mode.
+                </description>
+                <arg name="mode" type="uint" enum="mode"
+                     summary="the output's new power management mode"/>
+                </event>
+                
+                <event name="failed">
+                    <description summary="object no longer valid">
+                        This event indicates that the output power management mode control
+                        is no longer valid. This can happen for a number of reasons,
+                        including:
+                        - The output doesn't support power management
+                        - Another client already has exclusive power management mode control
+                        for this output
+                        - The output disappeared
+                        
+                        Upon receiving this event, the client should destroy this object.
+                    </description>
+                </event>
+                
+                <request name="destroy" type="destructor">
+                    <description summary="destroy this power management">
+                        Destroys the output power management mode control object.
+                    </description>
+                </request>
+            </interface>
+        </protocol>
+        

--- a/src/modules/dpms.c
+++ b/src/modules/dpms.c
@@ -171,7 +171,7 @@ static int method_setdpms(sd_bus_message *m, void *userdata, sd_bus_error *ret_e
     if (err) {
         switch (err) {
         case COMPOSITOR_NO_PROTOCOL:
-            sd_bus_error_set_const(ret_error, SD_BUS_ERROR_FAILED, "Compositor does not support 'org_kde_kwin_dpms' protocol.");
+            sd_bus_error_set_const(ret_error, SD_BUS_ERROR_FAILED, "Compositor does not support neither 'wlr-output-power-management-unstable-v1' nor 'org_kde_kwin_dpms' protocols.");
             break;
         case WRONG_PLUGIN:
             sd_bus_error_set_const(ret_error, SD_BUS_ERROR_FAILED, "No plugin available for your configuration.");

--- a/src/modules/dpms.h
+++ b/src/modules/dpms.h
@@ -3,7 +3,8 @@
 #define _DPMS_PLUGINS \
     X(XORG, 0) \
     X(WL, 1) \
-    X(DRM, 2)
+    X(KWIN_WL, 2) \
+    X(DRM, 3)
 
 enum dpms_plugins { 
 #define X(name, val) name = val,

--- a/src/modules/dpms_plugins/kwin_wl.c
+++ b/src/modules/dpms_plugins/kwin_wl.c
@@ -74,12 +74,11 @@ static void dpms_control_handle_done(void *data, struct org_kde_kwin_dpms *org_k
 
 static int wl_init(const char *display, const char *env) {
     int ret = 0;
-    struct wl_display *dpy = fetch_wl_display(display, env);
+    dpy = fetch_wl_display(display, env);
     if (dpy == NULL) {
         ret = WRONG_PLUGIN;
         return ret;
     }
-    
     wl_list_init(&outputs);
     dpms_registry = wl_display_get_registry(dpy);
     wl_registry_add_listener(dpms_registry, &registry_listener, NULL);
@@ -174,7 +173,7 @@ static int get(const char **display, const char *env) {
 
 static int set(const char **display, const char *env, int level) {
     int ret = wl_init(*display, env);
-     if (ret == 0) {
+    if (ret == 0) {
         struct output *output;
         wl_list_for_each(output, &outputs, link) {
             org_kde_kwin_dpms_set(output->dpms_control, level);


### PR DESCRIPTION
Old `Wl` implementation now lives under `KWin_wl` path. 
This is consistent with other wayland plugins that are wlroots protocols. 
Refs #99