### PR TITLE
fix(sensors): always prefer greater sysnum cameras (ie: external ones) when present

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,10 @@
 - [x] fix KWin_wl
 - [x] update wiki pages (new object path + wlroots as default under `Wl` obj path)
 
+### Camera
+- [x] always prefer greater sysnum cameras (ie: external ones) when present (refs https://github.com/FedeDP/Clight/issues/241)
+- [x] properly enumerate filtering by correct `ID_V4L_CAPABILITIES` being available (ie: `:capture:`)
+
 ### Generic
 - [x] port CI to gh actions
 

--- a/src/modules/sensors/als.c
+++ b/src/modules/sensors/als.c
@@ -27,7 +27,7 @@ static void fetch_dev(const char *interface, void **dev) {
     /* Check if any device exposes requested sysattr */
     for (int i = 0; i < SIZE(ill_names) && !*dev; i++) {
         /* Only check existence for needed sysattr */
-        const udev_match match = { ill_names[i] };
+        const udev_match match = { .sysattr_key = ill_names[i] };
         get_udev_device(interface, ALS_SUBSYSTEM, &match, NULL, (struct udev_device **)dev);
     }
 }

--- a/src/modules/sensors/camera.c
+++ b/src/modules/sensors/camera.c
@@ -7,6 +7,8 @@
 
 #define CAMERA_NAME                 "Camera"
 #define CAMERA_SUBSYSTEM            "video4linux"
+#define CAMERA_CAPTURE_PROP_NAME    "ID_V4L_CAPABILITIES"
+#define CAMERA_CAPTURE_PROP_VAL     ":capture:"
 
 struct buffer {
     uint8_t *start;
@@ -63,7 +65,11 @@ static bool validate_dev(void *dev) {
 }
 
 static void fetch_dev(const char *interface, void **dev) {
-    get_udev_device(interface, CAMERA_SUBSYSTEM, NULL, NULL, (struct udev_device **)dev);
+    // Note: we only filer cameras with capture prop val,
+    // and always start from greater sysnum (so that /dev/video2 has precedence over /dev/video0, when present).
+    // This means that external webcam are always preferred to internal ones,
+    // as they tend to have better resolution and increased image quality.
+    get_udev_device(interface, CAMERA_SUBSYSTEM, &(udev_match){.prop_key=CAMERA_CAPTURE_PROP_NAME, .prop_val=CAMERA_CAPTURE_PROP_VAL, .last_added = true}, NULL, (struct udev_device **)dev);
 }
 
 static void fetch_props_dev(void *dev, const char **node, const char **action) {

--- a/src/modules/sensors/yoctolight.c
+++ b/src/modules/sensors/yoctolight.c
@@ -144,7 +144,7 @@ static bool validate_dev(void *dev) {
 }
 
 static void fetch_dev(const char *interface, void **dev) {
-    const udev_match match = { YOCTO_PROPERTY, YOCTO_VENDORID };
+    const udev_match match = { .sysattr_key = YOCTO_PROPERTY, .sysattr_val = YOCTO_VENDORID };
     get_udev_device(interface, YOCTO_SUBSYSTEM, &match, NULL, (struct udev_device **)dev);
 }
 

--- a/src/utils/udev.c
+++ b/src/utils/udev.c
@@ -18,8 +18,12 @@ static void get_first_matching_device(struct udev_device **dev, const char *subs
     udev_enumerate_add_match_subsystem(enumerate, subsystem);
     bool last_added =false;
     if (match) {
-        udev_enumerate_add_match_sysattr(enumerate, match->sysattr_key, match->sysattr_val);
-        udev_enumerate_add_match_property(enumerate, match->prop_key, match->prop_val);
+        if (match->sysattr_key) {
+            udev_enumerate_add_match_sysattr(enumerate, match->sysattr_key, match->sysattr_val);
+        }
+        if (match->prop_key) {
+            udev_enumerate_add_match_property(enumerate, match->prop_key, match->prop_val);
+        }
         last_added = match->last_added;
     }
     udev_enumerate_scan_devices(enumerate);

--- a/src/utils/udev.h
+++ b/src/utils/udev.h
@@ -4,6 +4,9 @@ typedef struct {
     const char *sysattr_key;
     const char *sysattr_val;
     const char *sysname;
+    const char *prop_key;
+    const char *prop_val;
+    bool last_added;
 } udev_match;
 
 int init_udev_monitor(const char *subsystem, struct udev_monitor **mon);


### PR DESCRIPTION
Refs https://github.com/FedeDP/Clight/issues/241.
Moreover, properly filter by correct `ID_V4L_CAPABILITIES` being available (ie: `:capture:`) while enumerating camera devices.