### PR TITLE
fix(sensors): use USEC_INITIALIZED udev property instead of sysnum to find external webcams

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,18 +1,15 @@
 ## 5.x
 
-### CI
-
-- [ ] Support prebuilt artifacts (deb, rpm) build from as old as possible glibc version to reach widest compatibility
-- [ ] both master devel and release
-
 ### Pipewire
 - [ ] Fix set_camera_setting() impl -> how to get current value? how to set a new value?
 - [ ] Check pipewire 0.3.60 v4l2 changes 
 - [x] fix source of segfault
 - [x] fix node names, ose object.path instead of object id 
+- [x] use same algorithm as camera sensor to retrieve default camera (ie: the one with highest USEC_INITIALIZED property)
 
 ### Camera 
 - [x] Do not even try to open devices without correct ID_V4L_CAPABILITIES
+- [x] use USEC_INITIALIZED property instead of sysnum
 
 ### Backlight
 - [ ] Keep it up to date with possible ddcutil api changes

--- a/src/modules/sensors/camera.c
+++ b/src/modules/sensors/camera.c
@@ -5,11 +5,6 @@
 #include "camera.h"
 #include <jpeglib.h>
 
-#define CAMERA_NAME                 "Camera"
-#define CAMERA_SUBSYSTEM            "video4linux"
-#define CAMERA_CAPTURE_PROP_NAME    "ID_V4L_CAPABILITIES"
-#define CAMERA_CAPTURE_PROP_VAL     ":capture:"
-
 struct buffer {
     uint8_t *start;
     size_t length;
@@ -70,7 +65,7 @@ static bool validate_dev(void *dev) {
 }
 
 static void fetch_dev(const char *interface, void **dev) {
-    // Note: we only filer cameras with capture prop val,
+    // Note: we only filter cameras with capture prop val,
     // and always start from greater sysnum (so that /dev/video2 has precedence over /dev/video0, when present).
     // This means that external webcam are always preferred to internal ones,
     // as they tend to have better resolution and increased image quality.

--- a/src/modules/sensors/camera.h
+++ b/src/modules/sensors/camera.h
@@ -11,6 +11,11 @@
     #define INFO(fmt, ...)
 #endif
 
+#define CAMERA_NAME                 "Camera"
+#define CAMERA_SUBSYSTEM            "video4linux"
+#define CAMERA_CAPTURE_PROP_NAME    "ID_V4L_CAPABILITIES"
+#define CAMERA_CAPTURE_PROP_VAL     ":capture:"
+
 #define CAMERA_ILL_MAX              255
 #define HISTOGRAM_STEPS             40
 

--- a/src/utils/udev.c
+++ b/src/utils/udev.c
@@ -34,20 +34,21 @@ static void get_first_matching_device(struct udev_device **dev, const char *subs
             const char *path = udev_list_entry_get_name(devices);
             *dev = udev_device_new_from_syspath(udev, path);
         } else {
-            // Return last found, ie: the one with greatest index
+            // Return last found, ie: the one with largest USEC_INITIALIZED
             *dev = NULL;
             struct udev_list_entry *entry = NULL;
-            int max_sysnum = -1;
+            uint64_t max_usec_initialized = 0;
             udev_list_entry_foreach(entry, devices) {
                 const char *path = udev_list_entry_get_name(entry);
                 struct udev_device *d = udev_device_new_from_syspath(udev, path);
-                int sysnum = atoi(udev_device_get_sysnum(d));
-                if (sysnum > max_sysnum) {
+                const char *usec_initialized_str = udev_device_get_property_value(d, "USEC_INITIALIZED");
+                uint64_t usec_initialized = strtoll(usec_initialized_str, NULL, 10);
+                if (usec_initialized > max_usec_initialized) {
                     if (*dev) {
                         udev_device_unref(*dev);
                     }
                     *dev = d;
-                    max_sysnum = sysnum;
+                    max_usec_initialized = usec_initialized;
                 } else {
                     udev_device_unref(d);
                 }


### PR DESCRIPTION
Moreover, use same logic for pipewire sensor too.