### PR TITLE
Fix version string formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,17 @@ include(GNUInstallDirs)
 find_package(PkgConfig)
 
 execute_process(
-        COMMAND git log -1 --format=%h
+        COMMAND sh -c "test -d .git && git log -1 --format=%h"
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE GIT_HASH
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+if(GIT_HASH)
+    set(VERSION "${PROJECT_VERSION}-${GIT_HASH}")
+else()
+    set(VERSION "${PROJECT_VERSION}")
+endif()
 
 # Create program target
 file(GLOB SOURCES src/*.c src/utils/*.c src/modules/*.c src/modules/sensors/*.c src/modules/backlight_plugins/*.c)
@@ -26,7 +32,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 )
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     -D_GNU_SOURCE
-    -DVERSION="${PROJECT_VERSION}-${GIT_HASH}"
+    -DVERSION="${VERSION}"
 )
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)
 


### PR DESCRIPTION
This PR is in the same spirit as FedeDP/Clight#297.

TL;DR: Use git to retrieve the git commit hash only if the source directory looks like a git repository.

Please review and merge, or let me know how to improve it.